### PR TITLE
Some bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+chex
+core

--- a/buffer.c
+++ b/buffer.c
@@ -1,5 +1,10 @@
 #include "common.h"
 
+int ishexnumber(int c)
+{
+    return isdigit(c) || (c >= 97 && c <= 102) || (c >= 65 && c <= 70);
+}
+
 /* Get FP's size in bytes; keeps FP's file position indicator (fpi) at the
    beginning. Return -1 on error. */
 static long filesize(FILE *fp)

--- a/buffer.c
+++ b/buffer.c
@@ -48,7 +48,8 @@ void buf_init(char *filename)
 
 void buf_free()
 {
-    fclose(buf.fp);
+    if ( buf.fp )
+        fclose(buf.fp);
     free(buf.mem);
 }
 

--- a/route.c
+++ b/route.c
@@ -1,4 +1,7 @@
+#define _POSIX_SOURCE
+
 #include <signal.h>
+
 #include "common.h"
 
 /* Value of KEY when CTRL key is subsequently being held down (e.g. ^d and ^u.) */


### PR DESCRIPTION
Two things in this patchest:
- `ishexnumber` doesn't come with linux, so add a definition
- define `_POSIX_SOURCE` so that we get a signature for `kill()`
- Fix a segfault when opening the file fails
